### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Node dependencies
+npm ci


### PR DESCRIPTION
## Summary
- add `setup.sh` to install node dependencies before network lock-down

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_683c8cc85b50832eacb479712201ec96