### PR TITLE
Fix sign-in/out events and state updates

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -114,9 +114,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Get auth operations from custom hook
   const authOperations = useAuthOperations(profile, user, refreshProfile);
 
+  const signIn = async (email: string, password: string) => {
+    const { data, error } = await AuthService.signIn(email, password);
+    if (!error) {
+      const {
+        data: { session: currentSession },
+      } = await supabase.auth.getSession();
+      setSession(currentSession);
+      setUser(currentSession?.user ?? null);
+      if (currentSession?.user) {
+        await fetchUserProfile(currentSession.user.id, currentSession.user.email);
+      }
+    }
+    return { error };
+  };
+
   const signOut = async () => {
     console.log('🚪 Signing out...');
     setProfile(null);
+    setUser(null);
+    setSession(null);
     await AuthService.signOut();
   };
 
@@ -125,7 +142,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     session,
     profile,
     loading,
-    signIn: AuthService.signIn,
+    signIn,
     signUp: AuthService.signUp,
     signOut,
     refreshProfile,

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -4,18 +4,18 @@ import { supabase } from '@/integrations/supabase/client';
 export class AuthService {
   static async signIn(email: string, password: string) {
     console.log('🔐 Attempting sign in for:', email);
-    const { error } = await supabase.auth.signInWithPassword({
+    const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    
+
     if (error) {
       console.error('❌ Sign in error:', error);
     } else {
       console.log('✅ Sign in successful');
     }
-    
-    return { error };
+
+    return { data, error };
   }
 
   static async signUp(email: string, password: string, fullName?: string) {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,7 +17,10 @@ export interface AuthContextType {
   session: Session | null;
   profile: UserProfile | null;
   loading: boolean;
-  signIn: (email: string, password: string) => Promise<{ error: any }>;
+  signIn: (
+    email: string,
+    password: string
+  ) => Promise<{ data: any; error: any }>;
   signUp: (email: string, password: string, fullName?: string) => Promise<{ error: any }>;
   signOut: () => Promise<void>;
   hasRole: (role: UserRole) => boolean;


### PR DESCRIPTION
## Summary
- handle sign-in by updating context state immediately
- ensure sign-out clears local context state
- return session data from `AuthService.signIn`
- update typings for updated sign-in result

## Testing
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683c9dd5fc88832ea8bb6a86071daed5