### PR TITLE
Use env vars for Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,14 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 4. **Managing Admin Users**: Admin status and user lists are fetched through the new `adminService` and related hooks.
 
 These steps ensure the full authentication flow from initial admin creation through regular user registration and login.
+
+## Environment Variables
+
+Create a `.env` file in the project root with the following keys:
+
+```
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_PUBLISHABLE_KEY=<your-supabase-publishable-key>
+```
+
+These variables configure the Supabase client used by the application.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://vmglbdyrxnbucozwtscr.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZtZ2xiZHlyeG5idWNvend0c2NyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg0Mzk3MTAsImV4cCI6MjA2NDAxNTcxMH0.mvKcyTZzi6pytkNGYsuaToOvNgfd3JomjaVx_QNwPss";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,5 +40,7 @@ export default defineConfig(({ mode }) => ({
   // PWA optimizations
   define: {
     'process.env': {},
+    'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(process.env.VITE_SUPABASE_URL),
+    'import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY': JSON.stringify(process.env.VITE_SUPABASE_PUBLISHABLE_KEY),
   },
 }));


### PR DESCRIPTION
## Summary
- use `import.meta.env` for Supabase client
- expose VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY in Vite config
- document .env variables in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683cab414258832ebd8ab51db6e0ffc2