### PR TITLE
Switch to secure IndexedDB storage

### DIFF
--- a/src/components/DataMappingDialog.tsx
+++ b/src/components/DataMappingDialog.tsx
@@ -210,7 +210,7 @@ const DataMappingDialog: React.FC<DataMappingDialogProps> = ({
     }
   }, [sheetMapping, columnMapping, excelData]);
 
-  const handleImport = () => {
+  const handleImport = async () => {
     if (!excelData || !canProceed()) return;
     
     try {
@@ -285,8 +285,8 @@ const DataMappingDialog: React.FC<DataMappingDialogProps> = ({
         timestamp: new Date()
       };
 
-      saveImportSummary(importSummary);
-      addProductsToStorage(finalProducts);
+      await saveImportSummary(importSummary);
+      await addProductsToStorage(finalProducts);
       
       onMappingComplete(finalProducts, finalMapping);
       onOpenChange(false);

--- a/src/pages/Import.tsx
+++ b/src/pages/Import.tsx
@@ -9,6 +9,8 @@ import { Upload, FileSpreadsheet, CheckCircle, AlertCircle, Download } from 'luc
 import { useToast } from '@/hooks/use-toast';
 import * as XLSX from 'xlsx';
 import { useNavigate } from 'react-router-dom';
+import { secureSet } from '@/utils/secureStorage';
+import { serialize } from '@/utils/serialization';
 
 interface ExcelData {
   [key: string]: any;
@@ -265,7 +267,7 @@ const Import = () => {
     setStep('preview');
   };
 
-  const importData = () => {
+  const importData = async () => {
     // Transform Excel data to the required format
     const transformedData = excelData.map((row, index) => {
       const productData = {
@@ -372,8 +374,8 @@ const Import = () => {
       return productData;
     });
 
-    // Store the data (you can implement localStorage or pass to parent component)
-    localStorage.setItem('importedPharmaceuticalData', JSON.stringify(transformedData));
+    // Persist the data using secure storage
+    await secureSet('importedPharmaceuticalData', serialize(transformedData));
     
     toast({
       title: "Data Imported Successfully",

--- a/src/utils/secureStorage.ts
+++ b/src/utils/secureStorage.ts
@@ -1,0 +1,66 @@
+const DB_NAME = 'med_pulse_secure_db';
+const STORE_NAME = 'kv';
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDB(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => {
+        resolve(request.result);
+      };
+      request.onerror = () => {
+        reject(request.error);
+      };
+    });
+  }
+  return dbPromise;
+}
+
+export async function secureSet<T>(key: string, value: T): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(value, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function secureGet<T>(key: string): Promise<T | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(key);
+    req.onsuccess = () => resolve(req.result as T | undefined);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function secureRemove(key: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function secureClear(): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -1,0 +1,17 @@
+export const serialize = (data: any): string => {
+  return JSON.stringify(data, (_key, value) => {
+    if (value instanceof Date) {
+      return { __type: 'Date', value: value.toISOString() };
+    }
+    return value;
+  });
+};
+
+export const deserialize = <T = any>(text: string): T => {
+  return JSON.parse(text, (_key, value) => {
+    if (value && typeof value === 'object' && value.__type === 'Date') {
+      return new Date(value.value);
+    }
+    return value;
+  }) as T;
+};


### PR DESCRIPTION
## Summary
- create basic IndexedDB wrapper and serialization helpers
- migrate dataStorage utilities to use secure storage
- update Import page to persist using new helpers
- adapt DataMappingDialog to handle async storage calls

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683cab43175c832eb5bbbcc135a47e25