### PR TITLE
Implement profile save

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/components/profile/UserDetailsSection.tsx
+++ b/src/components/profile/UserDetailsSection.tsx
@@ -7,20 +7,35 @@ import { Label } from '@/components/ui/label';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import { ProfileService } from '@/services/auth/profileService';
 import { Edit, Save, X, User, Mail, MapPin, Calendar, Shield } from 'lucide-react';
 import { getRoleDisplayName } from '@/utils/roleMapping';
 
 export const UserDetailsSection = () => {
-  const { profile, user } = useAuth();
+  const { profile, user, refreshProfile } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [formData, setFormData] = useState({
     full_name: profile?.full_name || '',
     department: profile?.department || '',
   });
 
-  const handleSave = () => {
-    // TODO: Implement profile update functionality
-    console.log('Saving profile data:', formData);
+  const { toast } = useToast();
+
+  const handleSave = async () => {
+    if (!user) return;
+
+    const { error } = await ProfileService.updateProfile(user.id, formData);
+
+    if (error) {
+      console.error('Error updating profile:', error);
+      toast({ title: 'Error', description: 'Failed to update profile', variant: 'destructive' });
+      return;
+    }
+
+    toast({ title: 'Profile Updated', description: 'Your changes have been saved' });
+
+    await refreshProfile();
     setIsEditing(false);
   };
 

--- a/src/services/auth/__tests__/profileService.test.ts
+++ b/src/services/auth/__tests__/profileService.test.ts
@@ -1,0 +1,24 @@
+import { vi, describe, it, expect } from 'vitest';
+import { ProfileService } from '../profileService';
+import { supabase } from '@/integrations/supabase/client';
+
+vi.mock('@/integrations/supabase/client');
+
+describe('ProfileService.updateProfile', () => {
+  it('updates user profile fields', async () => {
+    const update = vi.fn().mockReturnThis();
+    const eq = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({ data: { id: '1', full_name: 'John', department: 'IT' }, error: null });
+
+    (supabase.from as any) = vi.fn(() => ({ update, eq, select, single }));
+
+    const { error, data } = await ProfileService.updateProfile('1', { full_name: 'John', department: 'IT' });
+
+    expect(error).toBeNull();
+    expect(data).toEqual({ id: '1', full_name: 'John', department: 'IT' });
+    expect(supabase.from).toHaveBeenCalledWith('profiles');
+    expect(update).toHaveBeenCalled();
+    expect(eq).toHaveBeenCalledWith('id', '1');
+  });
+});

--- a/src/services/auth/profileService.ts
+++ b/src/services/auth/profileService.ts
@@ -116,4 +116,28 @@ export class ProfileService {
       return { error };
     }
   }
+
+  static async updateProfile(userId: string, updates: Partial<Pick<UserProfile, 'full_name' | 'department'>>) {
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .update({
+          ...updates,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', userId)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ Error updating profile:', error);
+        return { data: null, error };
+      }
+
+      return { data: data as UserProfile, error: null };
+    } catch (error) {
+      console.error('💥 Unexpected error updating profile:', error);
+      return { data: null, error };
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- wire up user profile editing to Supabase
- add ProfileService.updateProfile
- create unit test for ProfileService
- add vitest test infrastructure

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683cab438154832e98b1495fb2588600