### PR TITLE
Add profile creation on signup

### DIFF
--- a/src/services/auth/__tests__/profileService.test.ts
+++ b/src/services/auth/__tests__/profileService.test.ts
@@ -22,3 +22,26 @@ describe('ProfileService.updateProfile', () => {
     expect(eq).toHaveBeenCalledWith('id', '1');
   });
 });
+
+describe('ProfileService.createProfile', () => {
+  it('inserts a new user profile', async () => {
+    const insert = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({ data: { id: '1', email: 'test@example.com', full_name: 'Test', approval_status: 'pending' }, error: null });
+
+    (supabase.from as any) = vi.fn(() => ({ insert, select, single }));
+
+    const { error, data } = await ProfileService.createProfile('1', 'test@example.com', 'Test');
+
+    expect(error).toBeNull();
+    expect(data).toEqual({ id: '1', email: 'test@example.com', full_name: 'Test', approval_status: 'pending' });
+    expect(supabase.from).toHaveBeenCalledWith('profiles');
+    expect(insert).toHaveBeenCalledWith({
+      id: '1',
+      email: 'test@example.com',
+      full_name: 'Test',
+      approval_status: 'pending',
+      is_active: true
+    });
+  });
+});

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -1,5 +1,6 @@
 
 import { supabase } from '@/integrations/supabase/client';
+import { ProfileService } from './profileService';
 
 export class AuthService {
   static async signIn(email: string, password: string) {
@@ -20,7 +21,7 @@ export class AuthService {
 
   static async signUp(email: string, password: string, fullName?: string) {
     console.log('📝 Attempting sign up for:', email);
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -29,14 +30,19 @@ export class AuthService {
         },
       },
     });
-    
+
     if (error) {
       console.error('❌ Sign up error:', error);
-    } else {
-      console.log('✅ Sign up successful');
+      return { error };
     }
-    
-    return { error };
+
+    console.log('✅ Sign up successful');
+
+    if (data.user) {
+      await ProfileService.createProfile(data.user.id, email, fullName);
+    }
+
+    return { error: null };
   }
 
   static async signOut() {

--- a/src/services/auth/profileService.ts
+++ b/src/services/auth/profileService.ts
@@ -80,6 +80,32 @@ export class ProfileService {
     }
   }
 
+  static async createProfile(userId: string, email: string, fullName?: string) {
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .insert({
+          id: userId,
+          email,
+          full_name: fullName ?? null,
+          approval_status: 'pending',
+          is_active: true
+        })
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ Error creating profile:', error);
+        return { data: null, error };
+      }
+
+      return { data: data as UserProfile, error: null };
+    } catch (error) {
+      console.error('💥 Unexpected error creating profile:', error);
+      return { data: null, error };
+    }
+  }
+
   static async updateUserRole(userId: string, newRole: UserRole, currentUserProfile: UserProfile | null, currentUserId?: string) {
     // Enhanced validation
     if (!isValidPharmaceuticalRole(newRole)) {


### PR DESCRIPTION
## Summary
- create a profile record via `ProfileService.createProfile`
- call new createProfile helper inside `AuthService.signUp`
- test profile creation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840134e37f8832e8333f08895149fd7