### PR TITLE
Fix auth user profile consistency

### DIFF
--- a/src/services/auth/__tests__/profileService.createProfile.test.ts
+++ b/src/services/auth/__tests__/profileService.createProfile.test.ts
@@ -1,0 +1,22 @@
+import { vi, describe, it, expect } from 'vitest';
+import { ProfileService } from '../profileService';
+import { supabase } from '@/integrations/supabase/client';
+
+vi.mock('@/integrations/supabase/client');
+
+describe('ProfileService.createProfile', () => {
+  it('inserts new profile record', async () => {
+    const insert = vi.fn().mockReturnThis();
+    const select = vi.fn().mockReturnThis();
+    const single = vi.fn().mockResolvedValue({ data: { id: '1', email: 'test@test.com' }, error: null });
+
+    (supabase.from as any) = vi.fn(() => ({ insert, select, single }));
+
+    const { error, data } = await ProfileService.createProfile('1', 'test@test.com', 'Test');
+
+    expect(error).toBeNull();
+    expect(data).toEqual({ id: '1', email: 'test@test.com' });
+    expect(supabase.from).toHaveBeenCalledWith('profiles');
+    expect(insert).toHaveBeenCalled();
+  });
+});

--- a/src/services/auth/profileService.ts
+++ b/src/services/auth/profileService.ts
@@ -140,4 +140,33 @@ export class ProfileService {
       return { data: null, error };
     }
   }
+
+  static async createProfile(userId: string, email: string, fullName?: string | null) {
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .insert({
+          id: userId,
+          email,
+          full_name: fullName ?? null,
+          role: 'viewer',
+          is_active: true,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          approval_status: 'pending'
+        })
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ Error creating profile:', error);
+        return { data: null, error };
+      }
+
+      return { data: data as UserProfile, error: null };
+    } catch (error) {
+      console.error('💥 Unexpected error creating profile:', error);
+      return { data: null, error };
+    }
+  }
 }

--- a/src/services/userManagement/__tests__/authValidationService.test.ts
+++ b/src/services/userManagement/__tests__/authValidationService.test.ts
@@ -1,0 +1,29 @@
+import { vi, describe, it, expect } from 'vitest';
+import { AuthValidationService } from '../authValidationService';
+import { supabase } from '@/integrations/supabase/client';
+import { ProfileService } from '@/services/auth/profileService';
+
+vi.mock('@/integrations/supabase/client');
+vi.mock('@/services/auth/profileService');
+
+describe('AuthValidationService.validateAuthUsers', () => {
+  it('creates missing profiles and returns true', async () => {
+    const listUsers = vi.fn().mockResolvedValue({
+      data: { users: [
+        { id: '1', email: 'a@test.com', user_metadata: { full_name: 'A' } },
+        { id: '2', email: 'b@test.com', user_metadata: { full_name: 'B' } }
+      ] },
+      error: null
+    });
+    (supabase.auth as any) = { admin: { listUsers } };
+
+    const createProfile = vi.fn().mockResolvedValue({ data: {}, error: null });
+    (ProfileService.createProfile as any) = createProfile;
+
+    const result = await AuthValidationService.validateAuthUsers(['1']);
+
+    expect(result).toBe(true);
+    expect(listUsers).toHaveBeenCalled();
+    expect(createProfile).toHaveBeenCalledWith('2', 'b@test.com', 'B');
+  });
+});

--- a/src/services/userManagement/authValidationService.ts
+++ b/src/services/userManagement/authValidationService.ts
@@ -1,6 +1,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { UserRole } from '@/types/pharmaceutical';
+import { ProfileService } from '@/services/auth/profileService';
 
 export class AuthValidationService {
   static async getCurrentUserInfo() {
@@ -37,7 +38,29 @@ export class AuthValidationService {
     try {
       console.log('🔍 Checking profiles data consistency...');
       console.log('📊 Current profiles count:', profileUserIds.length);
-      
+
+      const { data: authData, error: authError } = await supabase.auth.admin.listUsers();
+
+      if (authError) {
+        console.log('Error fetching auth users:', authError);
+        return false;
+      }
+
+      const authUsers = authData?.users || [];
+      const missingAuthUsers = authUsers.filter(u => !profileUserIds.includes(u.id));
+
+      if (missingAuthUsers.length > 0) {
+        console.log('➕ Creating profiles for auth users missing profiles:', missingAuthUsers.length);
+        for (const user of missingAuthUsers) {
+          await ProfileService.createProfile(
+            user.id,
+            user.email ?? '',
+            (user.user_metadata as any)?.full_name ?? null
+          );
+        }
+        return true;
+      }
+
       // Check if there are any profiles that might need attention (like missing fields)
       const { data: incompleteProfiles, error } = await supabase
         .from('profiles')


### PR DESCRIPTION
## Summary
- add `ProfileService.createProfile` for inserting new profiles
- ensure `validateAuthUsers` creates missing profiles and signals the caller
- add tests for the new functions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840134ff9d4832e9332c3a3f66532da