### PR TITLE
Secure listUsers call

### DIFF
--- a/src/services/userManagement/__tests__/authValidationService.test.ts
+++ b/src/services/userManagement/__tests__/authValidationService.test.ts
@@ -15,7 +15,7 @@ describe('AuthValidationService.validateAuthUsers', () => {
       ] },
       error: null
     });
-    (supabase.auth as any) = { admin: { listUsers } };
+    (supabase.functions as any) = { invoke: listUsers };
 
     const createProfile = vi.fn().mockResolvedValue({ data: {}, error: null });
     (ProfileService.createProfile as any) = createProfile;

--- a/src/services/userManagement/authValidationService.ts
+++ b/src/services/userManagement/authValidationService.ts
@@ -39,7 +39,7 @@ export class AuthValidationService {
       console.log('🔍 Checking profiles data consistency...');
       console.log('📊 Current profiles count:', profileUserIds.length);
 
-      const { data: authData, error: authError } = await supabase.auth.admin.listUsers();
+      const { data: authData, error: authError } = await supabase.functions.invoke('list-users');
 
       if (authError) {
         console.log('Error fetching auth users:', authError);

--- a/supabase/functions/list-users/index.ts
+++ b/supabase/functions/list-users/index.ts
@@ -1,0 +1,17 @@
+import { serve } from 'https://deno.land/std@0.192.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+serve(async (_req) => {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, serviceKey)
+
+  const { data, error } = await supabase.auth.admin.listUsers()
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 })
+  }
+
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+})


### PR DESCRIPTION
## Summary
- add Supabase edge function `list-users` to call `auth.admin.listUsers`
- fetch from the new function in `AuthValidationService`
- update tests for the new call

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684017857df4832e9a54a7d570e192fc