### PR TITLE
Use Supabase persistence

### DIFF
--- a/src/utils/facilityDataIntegration.ts
+++ b/src/utils/facilityDataIntegration.ts
@@ -1,7 +1,7 @@
 
 import { ProductData } from '@/types/pharmaceutical';
 import { HealthFacility } from '@/types/healthFacilities';
-import { dataAccess } from './dataAccessLayer';
+import { supabaseDataAccess as dataAccess } from './dataAccessLayer';
 import { useAuth } from '@/contexts/AuthContext';
 
 export interface FacilityProductData extends ProductData {

--- a/supabase/migrations/0001_create_pharma_tables.sql
+++ b/supabase/migrations/0001_create_pharma_tables.sql
@@ -1,0 +1,55 @@
+-- Products table
+create table if not exists products (
+  id uuid primary key default uuid_generate_v4(),
+  product_name text not null,
+  product_code text,
+  unit text not null,
+  unit_price numeric not null,
+  ven_classification text not null,
+  facility_specific boolean not null default false,
+  procurement_source text not null,
+  frequency text not null,
+  facility_id uuid references health_facilities(id) on delete cascade,
+  annual_consumption numeric default 0,
+  aamc numeric default 0,
+  wastage_rate numeric default 0,
+  awamc numeric default 0,
+  forecast jsonb,
+  seasonality jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  created_by uuid references auth.users(id)
+);
+
+-- Period data table
+create table if not exists period_data (
+  id uuid primary key default uuid_generate_v4(),
+  product_id uuid references products(id) on delete cascade,
+  period integer not null,
+  period_name text not null,
+  beginning_balance numeric default 0,
+  received numeric default 0,
+  positive_adj numeric default 0,
+  negative_adj numeric default 0,
+  ending_balance numeric default 0,
+  stock_out_days integer default 0,
+  expired_damaged numeric default 0,
+  consumption_issue numeric default 0,
+  aamc numeric default 0,
+  wastage_rate numeric default 0,
+  calculated_at timestamptz
+);
+create unique index if not exists period_data_product_period_idx on period_data(product_id, period);
+
+-- Import logs table
+create table if not exists import_logs (
+  id uuid primary key default uuid_generate_v4(),
+  filename text,
+  total_rows integer,
+  successful_rows integer,
+  error_rows integer,
+  warnings jsonb,
+  mapping jsonb,
+  imported_by uuid references auth.users(id),
+  imported_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- design Supabase SQL tables for products and period data
- replace InMemoryDataAccess with SupabaseDataAccess and expose `supabaseDataAccess`
- update facility integration to use the new data layer

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840179e9b0c832e9aadea960b1aa48e