### PR TITLE
Ensure new sign‑ups create profiles

### DIFF
--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuth } from '@/contexts/AuthContext';
+import { ProfileService } from '@/services/auth/profileService';
 import { toast } from 'sonner';
 
 interface SignUpFormProps {
@@ -43,17 +44,26 @@ export const SignUpForm = ({ isLoading, setIsLoading }: SignUpFormProps) => {
 
     try {
       console.log('🚀 Starting signup process for:', signUpData.email);
-      const { error } = await signUp(
+      const { data, error } = await signUp(
         signUpData.email,
         signUpData.password,
         signUpData.fullName
       );
-      
+
       if (error) {
         console.error('❌ Signup error:', error);
         toast.error(error.message || 'Failed to sign up');
       } else {
         console.log('✅ Signup successful for:', signUpData.email);
+
+        if (data?.user) {
+          await ProfileService.createProfile(
+            data.user.id,
+            signUpData.email,
+            signUpData.fullName
+          );
+        }
+
         toast.success('Account created successfully! Please check your email for verification.');
         // Clear form after successful signup
         setSignUpData({

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -20,7 +20,7 @@ export class AuthService {
 
   static async signUp(email: string, password: string, fullName?: string) {
     console.log('📝 Attempting sign up for:', email);
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -29,14 +29,14 @@ export class AuthService {
         },
       },
     });
-    
+
     if (error) {
       console.error('❌ Sign up error:', error);
     } else {
       console.log('✅ Sign up successful');
     }
-    
-    return { error };
+
+    return { data, error };
   }
 
   static async signOut() {

--- a/src/services/auth/profileService.ts
+++ b/src/services/auth/profileService.ts
@@ -80,6 +80,35 @@ export class ProfileService {
     }
   }
 
+  static async createProfile(userId: string, email: string, fullName?: string, role: UserRole = 'viewer') {
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .insert({
+          id: userId,
+          email,
+          full_name: fullName ?? null,
+          role,
+          approval_status: 'pending',
+          is_active: true,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        })
+        .select()
+        .single();
+
+      if (error) {
+        console.error('❌ Error creating profile:', error);
+        return { data: null, error };
+      }
+
+      return { data: data as UserProfile, error: null };
+    } catch (error) {
+      console.error('💥 Unexpected error creating profile:', error);
+      return { data: null, error };
+    }
+  }
+
   static async updateUserRole(userId: string, newRole: UserRole, currentUserProfile: UserProfile | null, currentUserId?: string) {
     // Enhanced validation
     if (!isValidPharmaceuticalRole(newRole)) {

--- a/src/services/userManagement/userQueryService.ts
+++ b/src/services/userManagement/userQueryService.ts
@@ -64,7 +64,7 @@ export class UserQueryService {
         id: user.id,
         email: user.email,
         full_name: user.full_name,
-        role: user.role as UserRole,
+        role: (user.role ?? 'viewer') as UserRole,
         facility_id: user.facility_id,
         department: user.department,
         is_active: user.is_active,


### PR DESCRIPTION
## Summary
- save `signUp` response data for profile creation
- add ProfileService.createProfile to insert new profiles
- create profile after sign up succeeds
- handle missing role data when mapping users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402f76c7f0832eb9004c10a218eeef