### PR TITLE
Fix product package size integration

### DIFF
--- a/src/components/data-management/ProductsDataTable.tsx
+++ b/src/components/data-management/ProductsDataTable.tsx
@@ -119,10 +119,14 @@ const ProductsDataTable = () => {
                 </div>
               </div>
               
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
                 <div>
                   <span className="text-gray-500 block">Unit:</span>
                   <span className="font-medium">{product.unit}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500 block">Package Size:</span>
+                  <span className="font-medium">{product.package_size ?? 'N/A'}</span>
                 </div>
                 <div>
                   <span className="text-gray-500 block">Unit Price:</span>

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -30,18 +30,18 @@ export const useCreateProduct = () => {
       }
 
       // Insert into the products table
-      const { data: product, error } = await supabase
-        .from('products')
-        .insert({
-          product_name: data.name,
-          product_code: data.code || `PRD-${Math.random().toString(36).substr(2, 6).toUpperCase()}`,
-          unit: data.unit,
-          unit_price: data.unitPrice,
-          ven_classification: data.venClassification,
+        const { data: product, error } = await supabase
+          .from('products')
+          .insert({
+            product_name: data.name,
+            product_code: data.code || `PRD-${Math.random().toString(36).substr(2, 6).toUpperCase()}`,
+            unit: data.unit,
+            package_size: data.packageSize,
+            unit_price: data.unitPrice,
+            ven_classification: data.venClassification,
           frequency: 'monthly', // Default frequency
           procurement_source: 'local', // Default procurement source
           created_by: user.id,
-          // Note: packageSize will need to be added to the products table schema
         })
         .select()
         .single();

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -411,10 +411,11 @@ export type Database = {
           id: string
           procurement_source: string
           product_code: string | null
-          product_name: string
-          seasonality: Json | null
-          unit: string
-          unit_price: number
+        product_name: string
+        seasonality: Json | null
+        unit: string
+        package_size: number | null
+        unit_price: number
           updated_at: string | null
           ven_classification: string
           wastage_rate: number | null
@@ -434,8 +435,9 @@ export type Database = {
           product_code?: string | null
           product_name: string
           seasonality?: Json | null
-          unit: string
-          unit_price: number
+        unit: string
+        package_size?: number | null
+        unit_price: number
           updated_at?: string | null
           ven_classification: string
           wastage_rate?: number | null
@@ -455,8 +457,9 @@ export type Database = {
           product_code?: string | null
           product_name?: string
           seasonality?: Json | null
-          unit?: string
-          unit_price?: number
+        unit?: string
+        package_size?: number | null
+        unit_price?: number
           updated_at?: string | null
           ven_classification?: string
           wastage_rate?: number | null

--- a/supabase/migrations/20250605_add_package_size_to_products.sql
+++ b/supabase/migrations/20250605_add_package_size_to_products.sql
@@ -1,0 +1,3 @@
+-- Add package_size column to products table
+ALTER TABLE products
+ADD COLUMN package_size numeric;


### PR DESCRIPTION
## Summary
- add migration for `package_size` column
- expose `package_size` in generated Supabase types
- insert `package_size` when creating a product
- display package size in product table

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415f95b3e8832eb0eaedd689ca6e70