### PR TITLE
Update profile service test expectation

### DIFF
--- a/src/services/auth/__tests__/profileService.test.ts
+++ b/src/services/auth/__tests__/profileService.test.ts
@@ -16,7 +16,15 @@ describe('ProfileService.updateProfile', () => {
     const { error, data } = await ProfileService.updateProfile('1', { full_name: 'John', department: 'IT' });
 
     expect(error).toBeNull();
-    expect(data).toEqual({ id: '1', full_name: 'John', department: 'IT' });
+    expect(data).toEqual({
+      id: '1',
+      email: undefined,
+      full_name: 'John',
+      role: 'facility_officer',
+      facility_id: undefined,
+      department: 'IT',
+      is_active: undefined
+    });
     expect(supabase.from).toHaveBeenCalledWith('profiles');
     expect(update).toHaveBeenCalled();
     expect(eq).toHaveBeenCalledWith('id', '1');


### PR DESCRIPTION
## Summary
- adjust the expected `UserProfile` shape in `profileService.test`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856f675de50832ebdd0c3cba154539c