### PR TITLE
Add created_at index migration

### DIFF
--- a/supabase/migrations/20250701_add_created_at_index.sql
+++ b/supabase/migrations/20250701_add_created_at_index.sql
@@ -1,0 +1,3 @@
+-- Improve ordering performance by indexing created_at
+CREATE INDEX idx_pharmaceutical_products_created_at
+  ON public.pharmaceutical_products (created_at DESC);


### PR DESCRIPTION
## Summary
- add migration to index `created_at` for better sorting performance

## Testing
- `npx supabase db push` *(fails: Cannot find project ref)*

------
https://chatgpt.com/codex/tasks/task_e_6856f926b454832ea5b17f4d3651fec6