### PR TITLE
Add Ethiopia 2025/26 summary dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Auth from '@/pages/Auth';
 import Dashboard from '@/pages/Dashboard';
 import PharmaceuticalProducts from '@/pages/PharmaceuticalProducts';
 import PharmaceuticalDashboardPage from '@/pages/PharmaceuticalDashboard';
+import Ethiopia2025_26 from '@/pages/Ethiopia2025_26';
 import DataManagement from '@/pages/DataManagement';
 import DataEntry from '@/pages/DataEntry';
 import Analytics from '@/pages/Analytics';
@@ -64,6 +65,13 @@ function App() {
                     <ProtectedRoute>
                       <AppLayout>
                         <PharmaceuticalDashboardPage />
+                      </AppLayout>
+                    </ProtectedRoute>
+                  } />
+                  <Route path="/ethiopia-2025-26" element={
+                    <ProtectedRoute>
+                      <AppLayout>
+                        <Ethiopia2025_26 />
                       </AppLayout>
                     </ProtectedRoute>
                   } />

--- a/src/components/layout/NavigationItems.tsx
+++ b/src/components/layout/NavigationItems.tsx
@@ -54,6 +54,13 @@ const NavigationItems = ({ className, onClick }: NavigationItemsProps) => {
       icon: BarChart3,
       requiresAuth: true,
       description: 'Insights and forecasting'
+    },
+    {
+      href: '/ethiopia-2025-26',
+      label: 'Ethiopia 2025/26',
+      icon: Map,
+      requiresAuth: true,
+      description: 'Annual summary dashboard'
     }
   ];
 

--- a/src/pages/Ethiopia2025_26.tsx
+++ b/src/pages/Ethiopia2025_26.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import PageHeader from '@/components/layout/PageHeader';
+import PharmaceuticalDashboard from '@/components/pharmaceutical/PharmaceuticalDashboard';
+import PharmaceuticalForecast from '@/components/pharmaceutical/PharmaceuticalForecast';
+
+const Ethiopia2025_26 = () => {
+  const breadcrumbItems = [
+    { label: 'Home', path: '/' },
+    { label: 'Ethiopia 2025/26' }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <PageHeader
+          title="Ethiopia 2025/26"
+          description="Summary of pharmaceutical products for the 2025/26 fiscal year"
+          breadcrumbItems={breadcrumbItems}
+        />
+
+        <div className="mt-8">
+          <Tabs defaultValue="summary" className="space-y-6">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="summary">Summary</TabsTrigger>
+              <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="summary">
+              <PharmaceuticalDashboard />
+            </TabsContent>
+
+            <TabsContent value="dashboard">
+              <PharmaceuticalForecast />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Ethiopia2025_26;


### PR DESCRIPTION
## Summary
- create a new Ethiopia 2025/26 page with summary and dashboard tabs
- register the new page in the router
- expose the page in the main navigation

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857702b74d4832e99721f9e0c9129fc