### PR TITLE
Optimize Ethiopia 2025/26 data loading

### DIFF
--- a/src/components/pharmaceutical/PharmaceuticalDashboard.tsx
+++ b/src/components/pharmaceutical/PharmaceuticalDashboard.tsx
@@ -4,18 +4,33 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line, Area, AreaChart } from 'recharts';
 import { Package, Building, MapPin, DollarSign, TrendingUp, AlertTriangle, Pill, ShoppingCart, RefreshCw } from 'lucide-react';
-import { usePharmaceuticalProducts } from '@/hooks/usePharmaceuticalProducts';
 import { Button } from '@/components/ui/button';
+import { PharmaceuticalProduct } from '@/types/pharmaceuticalProducts';
+
+interface PharmaceuticalMetricsSummary {
+  totalProducts: number;
+  totalValue: number;
+  uniqueFacilities: number;
+  uniqueRegions: number;
+}
+
+interface PharmaceuticalDashboardProps {
+  products: PharmaceuticalProduct[];
+  allProductsMetrics: PharmaceuticalMetricsSummary | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#84cc16', '#f97316'];
 
-const PharmaceuticalDashboard = () => {
-  // Use optimized hook with smaller page size for dashboard
-  const { products, allProductsMetrics, isLoading, error, refetch } = usePharmaceuticalProducts({}, { 
-    page: 1, 
-    pageSize: 25, // Smaller sample for dashboard performance
-    enablePagination: true 
-  });
+const PharmaceuticalDashboard = ({
+  products,
+  allProductsMetrics,
+  isLoading,
+  error,
+  refetch
+}: PharmaceuticalDashboardProps) => {
 
   const dashboardMetrics = useMemo(() => {
     if (!products.length) return null;

--- a/src/components/pharmaceutical/PharmaceuticalForecast.tsx
+++ b/src/components/pharmaceutical/PharmaceuticalForecast.tsx
@@ -3,18 +3,33 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell, LineChart, Line, ScatterChart, Scatter } from 'recharts';
 import { TrendingUp, AlertTriangle, Pill, Building, MapPin, DollarSign, Target, Activity, Package, RefreshCw } from 'lucide-react';
-import { usePharmaceuticalProducts } from '@/hooks/usePharmaceuticalProducts';
 import { Button } from '@/components/ui/button';
+import { PharmaceuticalProduct } from '@/types/pharmaceuticalProducts';
+
+interface PharmaceuticalMetricsSummary {
+  totalProducts: number;
+  totalValue: number;
+  uniqueFacilities: number;
+  uniqueRegions: number;
+}
+
+interface PharmaceuticalForecastProps {
+  products: PharmaceuticalProduct[];
+  allProductsMetrics: PharmaceuticalMetricsSummary | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#84cc16', '#f97316'];
 
-const PharmaceuticalForecast = () => {
-  // Use optimized hook with smaller sample for forecast analysis
-  const { products, allProductsMetrics, isLoading, error, refetch } = usePharmaceuticalProducts({}, { 
-    page: 1, 
-    pageSize: 50, // Larger sample for better forecast accuracy
-    enablePagination: true 
-  });
+const PharmaceuticalForecast = ({
+  products,
+  allProductsMetrics,
+  isLoading,
+  error,
+  refetch
+}: PharmaceuticalForecastProps) => {
 
   const forecastAnalysis = useMemo(() => {
     if (!products.length) return null;

--- a/src/pages/Ethiopia2025_26.tsx
+++ b/src/pages/Ethiopia2025_26.tsx
@@ -3,12 +3,21 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import PageHeader from '@/components/layout/PageHeader';
 import PharmaceuticalDashboard from '@/components/pharmaceutical/PharmaceuticalDashboard';
 import PharmaceuticalForecast from '@/components/pharmaceutical/PharmaceuticalForecast';
+import { usePharmaceuticalProducts } from '@/hooks/usePharmaceuticalProducts';
 
 const Ethiopia2025_26 = () => {
   const breadcrumbItems = [
     { label: 'Home', path: '/' },
     { label: 'Ethiopia 2025/26' }
   ];
+
+  const {
+    products,
+    allProductsMetrics,
+    isLoading,
+    error,
+    refetch
+  } = usePharmaceuticalProducts({}, { page: 1, pageSize: 50, enablePagination: true });
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -27,11 +36,23 @@ const Ethiopia2025_26 = () => {
             </TabsList>
 
             <TabsContent value="summary">
-              <PharmaceuticalDashboard />
+              <PharmaceuticalDashboard
+                products={products}
+                allProductsMetrics={allProductsMetrics}
+                isLoading={isLoading}
+                error={error}
+                refetch={refetch}
+              />
             </TabsContent>
 
             <TabsContent value="dashboard">
-              <PharmaceuticalForecast />
+              <PharmaceuticalForecast
+                products={products}
+                allProductsMetrics={allProductsMetrics}
+                isLoading={isLoading}
+                error={error}
+                refetch={refetch}
+              />
             </TabsContent>
           </Tabs>
         </div>

--- a/src/pages/PharmaceuticalDashboard.tsx
+++ b/src/pages/PharmaceuticalDashboard.tsx
@@ -4,12 +4,21 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import PageHeader from '@/components/layout/PageHeader';
 import PharmaceuticalDashboard from '@/components/pharmaceutical/PharmaceuticalDashboard';
 import PharmaceuticalForecast from '@/components/pharmaceutical/PharmaceuticalForecast';
+import { usePharmaceuticalProducts } from '@/hooks/usePharmaceuticalProducts';
 
 const PharmaceuticalDashboardPage = () => {
   const breadcrumbItems = [
     { label: 'Home', path: '/' },
     { label: 'Pharmaceutical Dashboard' }
   ];
+
+  const {
+    products,
+    allProductsMetrics,
+    isLoading,
+    error,
+    refetch
+  } = usePharmaceuticalProducts({}, { page: 1, pageSize: 50, enablePagination: true });
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -28,11 +37,23 @@ const PharmaceuticalDashboardPage = () => {
             </TabsList>
             
             <TabsContent value="overview">
-              <PharmaceuticalDashboard />
+              <PharmaceuticalDashboard
+                products={products}
+                allProductsMetrics={allProductsMetrics}
+                isLoading={isLoading}
+                error={error}
+                refetch={refetch}
+              />
             </TabsContent>
-            
+
             <TabsContent value="forecast">
-              <PharmaceuticalForecast />
+              <PharmaceuticalForecast
+                products={products}
+                allProductsMetrics={allProductsMetrics}
+                isLoading={isLoading}
+                error={error}
+                refetch={refetch}
+              />
             </TabsContent>
           </Tabs>
         </div>


### PR DESCRIPTION
## Summary
- pass a single pharmaceutical data load to dashboard and forecast tabs
- update Ethiopia 2025/26 and Pharmaceutical Dashboard pages to share data
- refactor dashboard and forecast components to accept data via props

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68577255e628832eb3ce9f1f7a58cbaa